### PR TITLE
Add Dependabot configuration files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Changes in this commit: Added `.github/dependabot.yml` files to two repositories (`cf7-ciuu-list` and `wp-security-headers`).

What is this change for? This change adds the necessary configuration files for using Dependabot to manage version updates for package ecosystems in the two repositories.

What security risks exist? No security risks exist in this change as it only adds configuration files.